### PR TITLE
feat: add pkg.pr.new preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,32 @@
+name: Publish Preview
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish preview
+        run: pnpm dlx pkg-pr-new publish


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflow for [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) to publish preview packages on every PR.

## Why is this useful?

When reviewing PRs, maintainers and contributors can **instantly test the changes** without waiting for a release:

1. No need to clone the repo and build locally
2. No need to publish a beta/canary version to npm
3. Anyone can verify fixes or test new features directly in their project

This speeds up the review process and helps catch issues before merging.

## How to use

When a PR is created, pkg.pr.new automatically comments with an install command:

```bash
npm i https://pkg.pr.new/htunnicliff/swr-openapi@{PR_NUMBER}
# or with specific commit
npm i https://pkg.pr.new/htunnicliff/swr-openapi@{COMMIT_SHA}
```

For example, to test PR #28:
```bash
npm i https://pkg.pr.new/htunnicliff/swr-openapi@28
```

Works with npm, yarn, pnpm, and bun.

## Requirements

The [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) needs to be installed on this repository for the workflow to post comments.