### PR TITLE
feat: add pkg.pr.new preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,35 @@
+name: Publish Preview
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+
+      - name: Setup Node
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish preview
+        run: |
+          pnpm dlx pkg-pr-new publish \
+            --packageManager=npm,pnpm,yarn,bun \
+            --compact \
+            --pnpm


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflow for [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) to publish preview packages on every PR.

## Why is this useful?

When reviewing PRs, maintainers and contributors can **instantly test the changes** without waiting for a release:

1. No need to clone the repo and build locally
2. No need to publish a beta/canary version to npm
3. Anyone can verify fixes or test new features directly in their project

This speeds up the review process and helps catch issues before merging.

## How to use

When a PR is created, pkg.pr.new automatically comments with an install command:

```bash
npm i https://pkg.pr.new/htunnicliff/swr-openapi@{PR_NUMBER}
# or with specific commit
npm i https://pkg.pr.new/htunnicliff/swr-openapi@{COMMIT_SHA}
```

Works with npm, yarn, pnpm, and bun.

## Requirements

The [pkg.pr.new GitHub App](https://github.com/apps/pkg-pr-new) needs to be installed on this repository for the workflow to post comments.

## Changes from #28
- Removed `push` trigger (only runs on PRs now)
- Pinned actions to match ci.yml
- Added `--packageManager`, `--compact`, and `--pnpm` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)